### PR TITLE
fix v2.3.0 build (referenced wrong commit)

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set version = "2.3.0" %}
-{% set sha256 = "e9b2c5e2559292575fd45165d2f6e5bab10ae5ee27116bc834b1cefb498c95ab" %}
+{% set sha256 = "0f34838f2c8024a6765168227ba587b3687729ebf03dc912f88ff75c7aa9cfe8" %}
 
 package:
     name: pybind11
@@ -11,7 +11,7 @@ source:
     sha256: {{ sha256 }}
 
 build:
-    number: 0
+    number: 1
 
 requirements:
     build:


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a fork of the feedstock to propose changes
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

I made a stupid mistaken when updating the feedstock to v2.3.0. The GitHub tag referenced the wrong commit (https://github.com/pybind/pybind11/issues/1805), which still has the "dev0" patch version but is otherwise identical to the v2.3.0 release. The PyPI release was unaffected and references the right version. I have bumped the build number.