### PR TITLE
TST adding pybind11 osx exception test

### DIFF
--- a/.azure-pipelines/azure-pipelines-linux.yml
+++ b/.azure-pipelines/azure-pipelines-linux.yml
@@ -10,20 +10,20 @@ jobs:
   strategy:
     maxParallel: 8
     matrix:
-      linux_python3.6.____73_pypy:
-        CONFIG: linux_python3.6.____73_pypy
+      linux_python3.6.____73_pypypython_implpypy:
+        CONFIG: linux_python3.6.____73_pypypython_implpypy
         UPLOAD_PACKAGES: True
         DOCKER_IMAGE: condaforge/linux-anvil-comp7
-      linux_python3.6.____cpython:
-        CONFIG: linux_python3.6.____cpython
+      linux_python3.6.____cpythonpython_implcpython:
+        CONFIG: linux_python3.6.____cpythonpython_implcpython
         UPLOAD_PACKAGES: True
         DOCKER_IMAGE: condaforge/linux-anvil-comp7
-      linux_python3.7.____cpython:
-        CONFIG: linux_python3.7.____cpython
+      linux_python3.7.____cpythonpython_implcpython:
+        CONFIG: linux_python3.7.____cpythonpython_implcpython
         UPLOAD_PACKAGES: True
         DOCKER_IMAGE: condaforge/linux-anvil-comp7
-      linux_python3.8.____cpython:
-        CONFIG: linux_python3.8.____cpython
+      linux_python3.8.____cpythonpython_implcpython:
+        CONFIG: linux_python3.8.____cpythonpython_implcpython
         UPLOAD_PACKAGES: True
         DOCKER_IMAGE: condaforge/linux-anvil-comp7
   steps:

--- a/.azure-pipelines/azure-pipelines-osx.yml
+++ b/.azure-pipelines/azure-pipelines-osx.yml
@@ -29,14 +29,6 @@ jobs:
       echo "Fast Finish"
       
 
-  - script: |
-      echo "Removing homebrew from Azure to avoid conflicts."
-      curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/uninstall > ~/uninstall_homebrew
-      chmod +x ~/uninstall_homebrew
-      ~/uninstall_homebrew -fq
-      rm ~/uninstall_homebrew
-    displayName: Remove homebrew
-
   - bash: |
       echo "##vso[task.prependpath]$CONDA/bin"
       sudo chown -R $USER $CONDA
@@ -46,6 +38,13 @@ jobs:
       source activate base
       conda install -n base -c conda-forge --quiet --yes conda-forge-ci-setup=2 conda-build
     displayName: 'Add conda-forge-ci-setup=2'
+
+  - script: |
+      echo "Mangling homebrew from Azure to avoid conflicts."
+      source activate base
+      /usr/bin/sudo mangle_homebrew
+      /usr/bin/sudo -k
+    displayName: Mangle homebrew
 
   - script: |
       source activate base

--- a/.azure-pipelines/azure-pipelines-osx.yml
+++ b/.azure-pipelines/azure-pipelines-osx.yml
@@ -10,17 +10,17 @@ jobs:
   strategy:
     maxParallel: 8
     matrix:
-      osx_python3.6.____73_pypy:
-        CONFIG: osx_python3.6.____73_pypy
+      osx_python3.6.____73_pypypython_implpypy:
+        CONFIG: osx_python3.6.____73_pypypython_implpypy
         UPLOAD_PACKAGES: True
-      osx_python3.6.____cpython:
-        CONFIG: osx_python3.6.____cpython
+      osx_python3.6.____cpythonpython_implcpython:
+        CONFIG: osx_python3.6.____cpythonpython_implcpython
         UPLOAD_PACKAGES: True
-      osx_python3.7.____cpython:
-        CONFIG: osx_python3.7.____cpython
+      osx_python3.7.____cpythonpython_implcpython:
+        CONFIG: osx_python3.7.____cpythonpython_implcpython
         UPLOAD_PACKAGES: True
-      osx_python3.8.____cpython:
-        CONFIG: osx_python3.8.____cpython
+      osx_python3.8.____cpythonpython_implcpython:
+        CONFIG: osx_python3.8.____cpythonpython_implcpython
         UPLOAD_PACKAGES: True
 
   steps:

--- a/.azure-pipelines/azure-pipelines-win.yml
+++ b/.azure-pipelines/azure-pipelines-win.yml
@@ -77,17 +77,14 @@ jobs:
     # Configure the VM.
     - script: |
         set "CI=azure"
+        call activate base
         run_conda_forge_build_setup
       displayName: conda-forge build setup
     
 
-    - script: |
-        rmdir C:\strawberry /s /q
-      continueOnError: true
-      displayName: remove strawberryperl
-
     # Special cased version setting some more things!
     - script: |
+        call activate base
         conda.exe build "recipe" -m .ci_support\%CONFIG%.yaml
       displayName: Build recipe (vs2008)
       env:
@@ -96,6 +93,7 @@ jobs:
       condition: contains(variables['CONFIG'], 'vs2008')
 
     - script: |
+        call activate base
         conda.exe build "recipe" -m .ci_support\%CONFIG%.yaml
       displayName: Build recipe
       env:
@@ -104,6 +102,7 @@ jobs:
 
     - script: |
         set "GIT_BRANCH=%BUILD_SOURCEBRANCHNAME%"
+        call activate base
         upload_package .\ ".\recipe" .ci_support\%CONFIG%.yaml
       displayName: Upload package
       env:

--- a/.ci_support/linux_aarch64_python3.6.____73_pypypython_implpypy.yaml
+++ b/.ci_support/linux_aarch64_python3.6.____73_pypypython_implpypy.yaml
@@ -1,16 +1,27 @@
+BUILD:
+- aarch64-conda_cos7-linux-gnu
+cdt_arch:
+- aarch64
+cdt_name:
+- cos7
 channel_sources:
-- conda-forge,defaults
+- conda-forge
 channel_targets:
 - conda-forge main
 cxx_compiler:
 - gxx
 cxx_compiler_version:
-- '8'
+- '7'
 docker_image:
-- condaforge/linux-anvil-ppc64le
+- condaforge/linux-anvil-aarch64
 pin_run_as_build:
   python:
     min_pin: x.x
     max_pin: x.x
 python:
 - 3.6.* *_73_pypy
+python_impl:
+- pypy
+zip_keys:
+- - python
+  - python_impl

--- a/.ci_support/linux_aarch64_python3.6.____cpythonpython_implcpython.yaml
+++ b/.ci_support/linux_aarch64_python3.6.____cpythonpython_implcpython.yaml
@@ -19,4 +19,9 @@ pin_run_as_build:
     min_pin: x.x
     max_pin: x.x
 python:
-- 3.6.* *_73_pypy
+- 3.6.* *_cpython
+python_impl:
+- cpython
+zip_keys:
+- - python
+  - python_impl

--- a/.ci_support/linux_aarch64_python3.7.____cpythonpython_implcpython.yaml
+++ b/.ci_support/linux_aarch64_python3.7.____cpythonpython_implcpython.yaml
@@ -19,4 +19,9 @@ pin_run_as_build:
     min_pin: x.x
     max_pin: x.x
 python:
-- 3.6.* *_cpython
+- 3.7.* *_cpython
+python_impl:
+- cpython
+zip_keys:
+- - python
+  - python_impl

--- a/.ci_support/linux_aarch64_python3.8.____cpythonpython_implcpython.yaml
+++ b/.ci_support/linux_aarch64_python3.8.____cpythonpython_implcpython.yaml
@@ -19,4 +19,9 @@ pin_run_as_build:
     min_pin: x.x
     max_pin: x.x
 python:
-- 3.7.* *_cpython
+- 3.8.* *_cpython
+python_impl:
+- cpython
+zip_keys:
+- - python
+  - python_impl

--- a/.ci_support/linux_ppc64le_python3.6.____73_pypypython_implpypy.yaml
+++ b/.ci_support/linux_ppc64le_python3.6.____73_pypypython_implpypy.yaml
@@ -1,20 +1,21 @@
-MACOSX_DEPLOYMENT_TARGET:
-- '10.9'
 channel_sources:
 - conda-forge,defaults
 channel_targets:
 - conda-forge main
 cxx_compiler:
-- clangxx
+- gxx
 cxx_compiler_version:
-- '9'
-macos_machine:
-- x86_64-apple-darwin13.4.0
-macos_min_version:
-- '10.9'
+- '8'
+docker_image:
+- condaforge/linux-anvil-ppc64le
 pin_run_as_build:
   python:
     min_pin: x.x
     max_pin: x.x
 python:
 - 3.6.* *_73_pypy
+python_impl:
+- pypy
+zip_keys:
+- - python
+  - python_impl

--- a/.ci_support/linux_ppc64le_python3.6.____cpythonpython_implcpython.yaml
+++ b/.ci_support/linux_ppc64le_python3.6.____cpythonpython_implcpython.yaml
@@ -1,20 +1,21 @@
-MACOSX_DEPLOYMENT_TARGET:
-- '10.9'
 channel_sources:
 - conda-forge,defaults
 channel_targets:
 - conda-forge main
 cxx_compiler:
-- clangxx
+- gxx
 cxx_compiler_version:
-- '9'
-macos_machine:
-- x86_64-apple-darwin13.4.0
-macos_min_version:
-- '10.9'
+- '8'
+docker_image:
+- condaforge/linux-anvil-ppc64le
 pin_run_as_build:
   python:
     min_pin: x.x
     max_pin: x.x
 python:
-- 3.7.* *_cpython
+- 3.6.* *_cpython
+python_impl:
+- cpython
+zip_keys:
+- - python
+  - python_impl

--- a/.ci_support/linux_ppc64le_python3.7.____cpythonpython_implcpython.yaml
+++ b/.ci_support/linux_ppc64le_python3.7.____cpythonpython_implcpython.yaml
@@ -1,22 +1,21 @@
-BUILD:
-- aarch64-conda_cos7-linux-gnu
-cdt_arch:
-- aarch64
-cdt_name:
-- cos7
 channel_sources:
-- conda-forge
+- conda-forge,defaults
 channel_targets:
 - conda-forge main
 cxx_compiler:
 - gxx
 cxx_compiler_version:
-- '7'
+- '8'
 docker_image:
-- condaforge/linux-anvil-aarch64
+- condaforge/linux-anvil-ppc64le
 pin_run_as_build:
   python:
     min_pin: x.x
     max_pin: x.x
 python:
-- 3.8.* *_cpython
+- 3.7.* *_cpython
+python_impl:
+- cpython
+zip_keys:
+- - python
+  - python_impl

--- a/.ci_support/linux_ppc64le_python3.8.____cpythonpython_implcpython.yaml
+++ b/.ci_support/linux_ppc64le_python3.8.____cpythonpython_implcpython.yaml
@@ -13,4 +13,9 @@ pin_run_as_build:
     min_pin: x.x
     max_pin: x.x
 python:
-- 3.6.* *_cpython
+- 3.8.* *_cpython
+python_impl:
+- cpython
+zip_keys:
+- - python
+  - python_impl

--- a/.ci_support/linux_python3.6.____73_pypypython_implpypy.yaml
+++ b/.ci_support/linux_python3.6.____73_pypypython_implpypy.yaml
@@ -5,12 +5,17 @@ channel_targets:
 cxx_compiler:
 - gxx
 cxx_compiler_version:
-- '8'
+- '7'
 docker_image:
-- condaforge/linux-anvil-ppc64le
+- condaforge/linux-anvil-comp7
 pin_run_as_build:
   python:
     min_pin: x.x
     max_pin: x.x
 python:
-- 3.8.* *_cpython
+- 3.6.* *_73_pypy
+python_impl:
+- pypy
+zip_keys:
+- - python
+  - python_impl

--- a/.ci_support/linux_python3.6.____cpythonpython_implcpython.yaml
+++ b/.ci_support/linux_python3.6.____cpythonpython_implcpython.yaml
@@ -14,3 +14,8 @@ pin_run_as_build:
     max_pin: x.x
 python:
 - 3.6.* *_cpython
+python_impl:
+- cpython
+zip_keys:
+- - python
+  - python_impl

--- a/.ci_support/linux_python3.7.____cpythonpython_implcpython.yaml
+++ b/.ci_support/linux_python3.7.____cpythonpython_implcpython.yaml
@@ -5,12 +5,17 @@ channel_targets:
 cxx_compiler:
 - gxx
 cxx_compiler_version:
-- '8'
+- '7'
 docker_image:
-- condaforge/linux-anvil-ppc64le
+- condaforge/linux-anvil-comp7
 pin_run_as_build:
   python:
     min_pin: x.x
     max_pin: x.x
 python:
 - 3.7.* *_cpython
+python_impl:
+- cpython
+zip_keys:
+- - python
+  - python_impl

--- a/.ci_support/linux_python3.8.____cpythonpython_implcpython.yaml
+++ b/.ci_support/linux_python3.8.____cpythonpython_implcpython.yaml
@@ -13,4 +13,9 @@ pin_run_as_build:
     min_pin: x.x
     max_pin: x.x
 python:
-- 3.7.* *_cpython
+- 3.8.* *_cpython
+python_impl:
+- cpython
+zip_keys:
+- - python
+  - python_impl

--- a/.ci_support/osx_python3.6.____73_pypypython_implpypy.yaml
+++ b/.ci_support/osx_python3.6.____73_pypypython_implpypy.yaml
@@ -1,16 +1,25 @@
+MACOSX_DEPLOYMENT_TARGET:
+- '10.9'
 channel_sources:
 - conda-forge,defaults
 channel_targets:
 - conda-forge main
 cxx_compiler:
-- gxx
+- clangxx
 cxx_compiler_version:
-- '7'
-docker_image:
-- condaforge/linux-anvil-comp7
+- '9'
+macos_machine:
+- x86_64-apple-darwin13.4.0
+macos_min_version:
+- '10.9'
 pin_run_as_build:
   python:
     min_pin: x.x
     max_pin: x.x
 python:
 - 3.6.* *_73_pypy
+python_impl:
+- pypy
+zip_keys:
+- - python
+  - python_impl

--- a/.ci_support/osx_python3.6.____cpythonpython_implcpython.yaml
+++ b/.ci_support/osx_python3.6.____cpythonpython_implcpython.yaml
@@ -17,4 +17,9 @@ pin_run_as_build:
     min_pin: x.x
     max_pin: x.x
 python:
-- 3.8.* *_cpython
+- 3.6.* *_cpython
+python_impl:
+- cpython
+zip_keys:
+- - python
+  - python_impl

--- a/.ci_support/osx_python3.7.____cpythonpython_implcpython.yaml
+++ b/.ci_support/osx_python3.7.____cpythonpython_implcpython.yaml
@@ -17,4 +17,9 @@ pin_run_as_build:
     min_pin: x.x
     max_pin: x.x
 python:
-- 3.6.* *_cpython
+- 3.7.* *_cpython
+python_impl:
+- cpython
+zip_keys:
+- - python
+  - python_impl

--- a/.ci_support/osx_python3.8.____cpythonpython_implcpython.yaml
+++ b/.ci_support/osx_python3.8.____cpythonpython_implcpython.yaml
@@ -1,16 +1,25 @@
+MACOSX_DEPLOYMENT_TARGET:
+- '10.9'
 channel_sources:
 - conda-forge,defaults
 channel_targets:
 - conda-forge main
 cxx_compiler:
-- gxx
+- clangxx
 cxx_compiler_version:
-- '7'
-docker_image:
-- condaforge/linux-anvil-comp7
+- '9'
+macos_machine:
+- x86_64-apple-darwin13.4.0
+macos_min_version:
+- '10.9'
 pin_run_as_build:
   python:
     min_pin: x.x
     max_pin: x.x
 python:
 - 3.8.* *_cpython
+python_impl:
+- cpython
+zip_keys:
+- - python
+  - python_impl

--- a/.ci_support/win_python3.6.____cpython.yaml
+++ b/.ci_support/win_python3.6.____cpython.yaml
@@ -10,3 +10,8 @@ pin_run_as_build:
     max_pin: x.x
 python:
 - 3.6.* *_cpython
+python_impl:
+- cpython
+zip_keys:
+- - python
+  - python_impl

--- a/.ci_support/win_python3.6.____cpython.yaml
+++ b/.ci_support/win_python3.6.____cpython.yaml
@@ -3,7 +3,7 @@ channel_sources:
 channel_targets:
 - conda-forge main
 cxx_compiler:
-- vs2015
+- vs2017
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/.ci_support/win_python3.7.____cpython.yaml
+++ b/.ci_support/win_python3.7.____cpython.yaml
@@ -3,7 +3,7 @@ channel_sources:
 channel_targets:
 - conda-forge main
 cxx_compiler:
-- vs2015
+- vs2017
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/.ci_support/win_python3.7.____cpython.yaml
+++ b/.ci_support/win_python3.7.____cpython.yaml
@@ -10,3 +10,8 @@ pin_run_as_build:
     max_pin: x.x
 python:
 - 3.7.* *_cpython
+python_impl:
+- cpython
+zip_keys:
+- - python
+  - python_impl

--- a/.ci_support/win_python3.8.____cpython.yaml
+++ b/.ci_support/win_python3.8.____cpython.yaml
@@ -3,7 +3,7 @@ channel_sources:
 channel_targets:
 - conda-forge main
 cxx_compiler:
-- vs2015
+- vs2017
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/.ci_support/win_python3.8.____cpython.yaml
+++ b/.ci_support/win_python3.8.____cpython.yaml
@@ -10,3 +10,8 @@ pin_run_as_build:
     max_pin: x.x
 python:
 - 3.8.* *_cpython
+python_impl:
+- cpython
+zip_keys:
+- - python
+  - python_impl

--- a/.drone.yml
+++ b/.drone.yml
@@ -1,6 +1,6 @@
 ---
 kind: pipeline
-name: linux_aarch64_python3.6.____73_pypy
+name: linux_aarch64_python3.6.____73_pypy_h1ac9c90734
 
 platform:
   os: linux
@@ -10,7 +10,7 @@ steps:
 - name: Install and build
   image: condaforge/linux-anvil-aarch64
   environment:
-    CONFIG: linux_aarch64_python3.6.____73_pypy
+    CONFIG: linux_aarch64_python3.6.____73_pypypython_implpypy
     UPLOAD_PACKAGES: True
     PLATFORM: linux-aarch64
     BINSTAR_TOKEN: 
@@ -26,7 +26,7 @@ steps:
 
 ---
 kind: pipeline
-name: linux_aarch64_python3.6.____cpython
+name: linux_aarch64_python3.6.____cpython_h4cd5b88306
 
 platform:
   os: linux
@@ -36,7 +36,7 @@ steps:
 - name: Install and build
   image: condaforge/linux-anvil-aarch64
   environment:
-    CONFIG: linux_aarch64_python3.6.____cpython
+    CONFIG: linux_aarch64_python3.6.____cpythonpython_implcpython
     UPLOAD_PACKAGES: True
     PLATFORM: linux-aarch64
     BINSTAR_TOKEN: 
@@ -52,7 +52,7 @@ steps:
 
 ---
 kind: pipeline
-name: linux_aarch64_python3.7.____cpython
+name: linux_aarch64_python3.7.____cpython_he9f51abab6
 
 platform:
   os: linux
@@ -62,7 +62,7 @@ steps:
 - name: Install and build
   image: condaforge/linux-anvil-aarch64
   environment:
-    CONFIG: linux_aarch64_python3.7.____cpython
+    CONFIG: linux_aarch64_python3.7.____cpythonpython_implcpython
     UPLOAD_PACKAGES: True
     PLATFORM: linux-aarch64
     BINSTAR_TOKEN: 
@@ -78,7 +78,7 @@ steps:
 
 ---
 kind: pipeline
-name: linux_aarch64_python3.8.____cpython
+name: linux_aarch64_python3.8.____cpython_h079251ed73
 
 platform:
   os: linux
@@ -88,7 +88,7 @@ steps:
 - name: Install and build
   image: condaforge/linux-anvil-aarch64
   environment:
-    CONFIG: linux_aarch64_python3.8.____cpython
+    CONFIG: linux_aarch64_python3.8.____cpythonpython_implcpython
     UPLOAD_PACKAGES: True
     PLATFORM: linux-aarch64
     BINSTAR_TOKEN: 

--- a/.scripts/run_docker_build.sh
+++ b/.scripts/run_docker_build.sh
@@ -52,8 +52,10 @@ mkdir -p "$ARTIFACTS"
 DONE_CANARY="$ARTIFACTS/conda-forge-build-done-${CONFIG}"
 rm -f "$DONE_CANARY"
 
+# Allow people to specify extra default arguments to `docker run` (e.g. `--rm`)
+DOCKER_RUN_ARGS="${CONDA_FORGE_DOCKER_RUN_ARGS}"
 if [ -z "${CI}" ]; then
-    DOCKER_RUN_ARGS="-it "
+    DOCKER_RUN_ARGS="-it ${DOCKER_RUN_ARGS}"
 fi
 
 export UPLOAD_PACKAGES="${UPLOAD_PACKAGES:-True}"

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,19 +10,19 @@ env:
 
 matrix:
   include:
-    - env: CONFIG=linux_ppc64le_python3.6.____73_pypy UPLOAD_PACKAGES=True PLATFORM=linux-ppc64le DOCKER_IMAGE=condaforge/linux-anvil-ppc64le
+    - env: CONFIG=linux_ppc64le_python3.6.____73_pypypython_implpypy UPLOAD_PACKAGES=True PLATFORM=linux-ppc64le DOCKER_IMAGE=condaforge/linux-anvil-ppc64le
       os: linux
       arch: ppc64le
 
-    - env: CONFIG=linux_ppc64le_python3.6.____cpython UPLOAD_PACKAGES=True PLATFORM=linux-ppc64le DOCKER_IMAGE=condaforge/linux-anvil-ppc64le
+    - env: CONFIG=linux_ppc64le_python3.6.____cpythonpython_implcpython UPLOAD_PACKAGES=True PLATFORM=linux-ppc64le DOCKER_IMAGE=condaforge/linux-anvil-ppc64le
       os: linux
       arch: ppc64le
 
-    - env: CONFIG=linux_ppc64le_python3.7.____cpython UPLOAD_PACKAGES=True PLATFORM=linux-ppc64le DOCKER_IMAGE=condaforge/linux-anvil-ppc64le
+    - env: CONFIG=linux_ppc64le_python3.7.____cpythonpython_implcpython UPLOAD_PACKAGES=True PLATFORM=linux-ppc64le DOCKER_IMAGE=condaforge/linux-anvil-ppc64le
       os: linux
       arch: ppc64le
 
-    - env: CONFIG=linux_ppc64le_python3.8.____cpython UPLOAD_PACKAGES=True PLATFORM=linux-ppc64le DOCKER_IMAGE=condaforge/linux-anvil-ppc64le
+    - env: CONFIG=linux_ppc64le_python3.8.____cpythonpython_implcpython UPLOAD_PACKAGES=True PLATFORM=linux-ppc64le DOCKER_IMAGE=condaforge/linux-anvil-ppc64le
       os: linux
       arch: ppc64le
 

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Current build status
     <td>Drone</td>
     <td>
       <a href="https://cloud.drone.io/conda-forge/pybind11-feedstock">
-        <img alt="linux" src="https://img.shields.io/drone/build/conda-forge/master.svg?label=Linux">
+        <img alt="linux" src="https://img.shields.io/drone/build/conda-forge/pybind11-feedstock/master.svg?label=Linux">
       </a>
     </td>
   </tr>

--- a/README.md
+++ b/README.md
@@ -43,115 +43,115 @@ Current build status
         <table>
           <thead><tr><th>Variant</th><th>Status</th></tr></thead>
           <tbody><tr>
-              <td>linux_aarch64_python3.6.____73_pypy</td>
+              <td>linux_aarch64_python3.6.____73_pypypython_implpypy</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=841&branchName=master">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/pybind11-feedstock?branchName=master&jobName=linux&configuration=linux_aarch64_python3.6.____73_pypy" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/pybind11-feedstock?branchName=master&jobName=linux&configuration=linux_aarch64_python3.6.____73_pypypython_implpypy" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>linux_aarch64_python3.6.____cpython</td>
+              <td>linux_aarch64_python3.6.____cpythonpython_implcpython</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=841&branchName=master">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/pybind11-feedstock?branchName=master&jobName=linux&configuration=linux_aarch64_python3.6.____cpython" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/pybind11-feedstock?branchName=master&jobName=linux&configuration=linux_aarch64_python3.6.____cpythonpython_implcpython" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>linux_aarch64_python3.7.____cpython</td>
+              <td>linux_aarch64_python3.7.____cpythonpython_implcpython</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=841&branchName=master">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/pybind11-feedstock?branchName=master&jobName=linux&configuration=linux_aarch64_python3.7.____cpython" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/pybind11-feedstock?branchName=master&jobName=linux&configuration=linux_aarch64_python3.7.____cpythonpython_implcpython" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>linux_aarch64_python3.8.____cpython</td>
+              <td>linux_aarch64_python3.8.____cpythonpython_implcpython</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=841&branchName=master">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/pybind11-feedstock?branchName=master&jobName=linux&configuration=linux_aarch64_python3.8.____cpython" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/pybind11-feedstock?branchName=master&jobName=linux&configuration=linux_aarch64_python3.8.____cpythonpython_implcpython" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>linux_ppc64le_python3.6.____73_pypy</td>
+              <td>linux_ppc64le_python3.6.____73_pypypython_implpypy</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=841&branchName=master">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/pybind11-feedstock?branchName=master&jobName=linux&configuration=linux_ppc64le_python3.6.____73_pypy" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/pybind11-feedstock?branchName=master&jobName=linux&configuration=linux_ppc64le_python3.6.____73_pypypython_implpypy" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>linux_ppc64le_python3.6.____cpython</td>
+              <td>linux_ppc64le_python3.6.____cpythonpython_implcpython</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=841&branchName=master">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/pybind11-feedstock?branchName=master&jobName=linux&configuration=linux_ppc64le_python3.6.____cpython" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/pybind11-feedstock?branchName=master&jobName=linux&configuration=linux_ppc64le_python3.6.____cpythonpython_implcpython" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>linux_ppc64le_python3.7.____cpython</td>
+              <td>linux_ppc64le_python3.7.____cpythonpython_implcpython</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=841&branchName=master">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/pybind11-feedstock?branchName=master&jobName=linux&configuration=linux_ppc64le_python3.7.____cpython" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/pybind11-feedstock?branchName=master&jobName=linux&configuration=linux_ppc64le_python3.7.____cpythonpython_implcpython" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>linux_ppc64le_python3.8.____cpython</td>
+              <td>linux_ppc64le_python3.8.____cpythonpython_implcpython</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=841&branchName=master">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/pybind11-feedstock?branchName=master&jobName=linux&configuration=linux_ppc64le_python3.8.____cpython" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/pybind11-feedstock?branchName=master&jobName=linux&configuration=linux_ppc64le_python3.8.____cpythonpython_implcpython" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>linux_python3.6.____73_pypy</td>
+              <td>linux_python3.6.____73_pypypython_implpypy</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=841&branchName=master">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/pybind11-feedstock?branchName=master&jobName=linux&configuration=linux_python3.6.____73_pypy" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/pybind11-feedstock?branchName=master&jobName=linux&configuration=linux_python3.6.____73_pypypython_implpypy" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>linux_python3.6.____cpython</td>
+              <td>linux_python3.6.____cpythonpython_implcpython</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=841&branchName=master">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/pybind11-feedstock?branchName=master&jobName=linux&configuration=linux_python3.6.____cpython" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/pybind11-feedstock?branchName=master&jobName=linux&configuration=linux_python3.6.____cpythonpython_implcpython" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>linux_python3.7.____cpython</td>
+              <td>linux_python3.7.____cpythonpython_implcpython</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=841&branchName=master">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/pybind11-feedstock?branchName=master&jobName=linux&configuration=linux_python3.7.____cpython" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/pybind11-feedstock?branchName=master&jobName=linux&configuration=linux_python3.7.____cpythonpython_implcpython" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>linux_python3.8.____cpython</td>
+              <td>linux_python3.8.____cpythonpython_implcpython</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=841&branchName=master">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/pybind11-feedstock?branchName=master&jobName=linux&configuration=linux_python3.8.____cpython" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/pybind11-feedstock?branchName=master&jobName=linux&configuration=linux_python3.8.____cpythonpython_implcpython" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>osx_python3.6.____73_pypy</td>
+              <td>osx_python3.6.____73_pypypython_implpypy</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=841&branchName=master">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/pybind11-feedstock?branchName=master&jobName=osx&configuration=osx_python3.6.____73_pypy" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/pybind11-feedstock?branchName=master&jobName=osx&configuration=osx_python3.6.____73_pypypython_implpypy" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>osx_python3.6.____cpython</td>
+              <td>osx_python3.6.____cpythonpython_implcpython</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=841&branchName=master">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/pybind11-feedstock?branchName=master&jobName=osx&configuration=osx_python3.6.____cpython" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/pybind11-feedstock?branchName=master&jobName=osx&configuration=osx_python3.6.____cpythonpython_implcpython" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>osx_python3.7.____cpython</td>
+              <td>osx_python3.7.____cpythonpython_implcpython</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=841&branchName=master">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/pybind11-feedstock?branchName=master&jobName=osx&configuration=osx_python3.7.____cpython" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/pybind11-feedstock?branchName=master&jobName=osx&configuration=osx_python3.7.____cpythonpython_implcpython" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>osx_python3.8.____cpython</td>
+              <td>osx_python3.8.____cpythonpython_implcpython</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=841&branchName=master">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/pybind11-feedstock?branchName=master&jobName=osx&configuration=osx_python3.8.____cpython" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/pybind11-feedstock?branchName=master&jobName=osx&configuration=osx_python3.8.____cpythonpython_implcpython" alt="variant">
                 </a>
               </td>
             </tr><tr>

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -27,13 +27,13 @@ requirements:
     - python
 
 test:
-  requires:                         # [osx]
-    - {{ compiler('cxx') }}         # [osx]
-    - make                          # [osx]
-    - pip                           # [osx]
-  files:                            # [osx]
-    - pybind11_exception_rtti_test  # [osx]
-    - run_exception_rtti_test.sh    # [osx]
+  requires:                         # [osx and python_impl == 'cpython']
+    - {{ compiler('cxx') }}         # [osx and python_impl == 'cpython']
+    - make                          # [osx and python_impl == 'cpython']
+    - pip                           # [osx and python_impl == 'cpython']
+  files:                            # [osx and python_impl == 'cpython']
+    - pybind11_exception_rtti_test  # [osx and python_impl == 'cpython']
+    - run_exception_rtti_test.sh    # [osx and python_impl == 'cpython']
   imports:
     - pybind11
   commands:
@@ -43,7 +43,7 @@ test:
     - if exist %LIBRARY_INC%\pybind11\pybind11.h (exit 0) else (exit 1)      # [win]
     - test -f $(python -c "import pybind11 as py; print(py.get_include())")/pybind11/pybind11.h      # [unix]
     - if exist $(python -c "import pybind11 as py; print(py.get_include())")\pybind11\pybind11.h (exit 0) else (exit 1)      # [win]
-    - bash run_exception_rtti_test.sh  # [osx]
+    - bash run_exception_rtti_test.sh  # [osx and python_impl == 'cpython']
 
 about:
   home: https://github.com/pybind/pybind11/

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -43,7 +43,7 @@ test:
     - if exist %LIBRARY_INC%\pybind11\pybind11.h (exit 0) else (exit 1)      # [win]
     - test -f $(python -c "import pybind11 as py; print(py.get_include())")/pybind11/pybind11.h      # [unix]
     - if exist $(python -c "import pybind11 as py; print(py.get_include())")\pybind11\pybind11.h (exit 0) else (exit 1)      # [win]
-    - bash exception_rtti_test.sh  # [osx]
+    - bash run_exception_rtti_test.sh  # [osx]
 
 about:
   home: https://github.com/pybind/pybind11/

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,7 +13,7 @@ source:
     - gh2146.patch
 
 build:
-  number: 0
+  number: 1
 
 requirements:
   build:
@@ -27,6 +27,13 @@ requirements:
     - python
 
 test:
+  requires:                         # [osx]
+    - {{ compiler('cxx') }}         # [osx]
+    - make                          # [osx]
+    - pip                           # [osx]
+  files:                            # [osx]
+    - pybind11_exception_rtti_test  # [osx]
+    - run_exception_rtti_test.sh    # [osx]
   imports:
     - pybind11
   commands:
@@ -36,6 +43,7 @@ test:
     - if exist %LIBRARY_INC%\pybind11\pybind11.h (exit 0) else (exit 1)      # [win]
     - test -f $(python -c "import pybind11 as py; print(py.get_include())")/pybind11/pybind11.h      # [unix]
     - if exist $(python -c "import pybind11 as py; print(py.get_include())")\pybind11\pybind11.h (exit 0) else (exit 1)      # [win]
+    - bash exception_rtti_test.sh  # [osx]
 
 about:
   home: https://github.com/pybind/pybind11/

--- a/recipe/pybind11_exception_rtti_test/.gitignore
+++ b/recipe/pybind11_exception_rtti_test/.gitignore
@@ -1,0 +1,4 @@
+*.o
+*.so
+*.dylib
+*.egg-info

--- a/recipe/pybind11_exception_rtti_test/Makefile
+++ b/recipe/pybind11_exception_rtti_test/Makefile
@@ -1,0 +1,50 @@
+COMP=clang
+ifeq ($(shell uname -s), Linux)
+EXTRA_FLAGS=
+PRINTLIBS=LD_LIBRARY_PATH=../src
+SUFFIX=$(shell python3-config --extension-suffix)
+SOEXT=.so
+else
+EXTRA_FLAGS=-undefined dynamic_lookup
+PRINTLIBS=DYLD_FALLBACK_LIBRARY_PATH=../src DYLD_PRINT_LIBRARIES=YES
+SUFFIX=$(shell python3-config --extension-suffix)
+CXXFLAGS=-fPIC -O2 -stdlib=libc++ -std=c++14 -isystem ${PREFIX}/include
+SOEXT=.dylib
+LDFLAGS=-Wl,-rpath,${PREFIX}/lib -L${PREFIX}/lib -mlinker-version=${TEST_LD_VER}
+endif
+
+test: clean pymod
+	cd tests && \
+	${COMP} ${CXXFLAGS} ${LDFLAGS} ${EXTRA_FLAGS} -shared -fPIC \
+		`python -m pybind11 --includes` \
+		testLib.cc \
+		-L../src -lException \
+		-o testLib${SUFFIX} && \
+		echo "\n\n============================================\ntesting\n============================================\n" && \
+	  ${PRINTLIBS} python test_exception_catching_python.py && \
+	cd -
+
+# chmod u+x testLib`python3-config --extension-suffix` && \
+
+pymod: cpp
+	cd exception_test && \
+	${COMP} ${CXXFLAGS} ${LDFLAGS} ${EXTRA_FLAGS} -shared -fPIC \
+		`python -m pybind11 --includes` \
+		exceptions.cc \
+		-L../src -lException \
+		-o exceptions${SUFFIX} && \
+	cd - && \
+	python -m pip install -e .
+
+cpp:
+	cd src && \
+	${COMP} ${CXXFLAGS} ${LDFLAGS} ${EXTRA_FLAGS} -shared -fPIC \
+		Exception.cc \
+		-o libException${SOEXT} && \
+	cd -
+
+clean:
+	rm -f \
+		src/*.o src/*.so src/*.dylib \
+		tests/*.o tests/*.so tests/*.dylib \
+		exception_test/*.o exception_test/*.so exception_test/*.dylib

--- a/recipe/pybind11_exception_rtti_test/Makefile
+++ b/recipe/pybind11_exception_rtti_test/Makefile
@@ -8,9 +8,9 @@ else
 EXTRA_FLAGS=-undefined dynamic_lookup
 PRINTLIBS=DYLD_FALLBACK_LIBRARY_PATH=../src DYLD_PRINT_LIBRARIES=YES
 SUFFIX=$(shell python3-config --extension-suffix)
-CXXFLAGS=-fPIC -O2 -stdlib=libc++ -std=c++14 -isystem ${PREFIX}/include
+# CXXFLAGS=-fPIC -O2 -stdlib=libc++ -std=c++14 -isystem ${PREFIX}/include
 SOEXT=.dylib
-LDFLAGS=-Wl,-rpath,${PREFIX}/lib -L${PREFIX}/lib -mlinker-version=${TEST_LD_VER}
+# LDFLAGS="${LDFLAGS}"-Wl,-rpath,${PREFIX}/lib -L${PREFIX}/lib -mlinker-version=${TEST_LD_VER}
 endif
 
 test: clean pymod

--- a/recipe/pybind11_exception_rtti_test/Makefile
+++ b/recipe/pybind11_exception_rtti_test/Makefile
@@ -1,4 +1,4 @@
-COMP=clang
+COMP=${CXX}
 ifeq ($(shell uname -s), Linux)
 EXTRA_FLAGS=
 PRINTLIBS=LD_LIBRARY_PATH=../src
@@ -8,9 +8,7 @@ else
 EXTRA_FLAGS=-undefined dynamic_lookup
 PRINTLIBS=DYLD_FALLBACK_LIBRARY_PATH=../src DYLD_PRINT_LIBRARIES=YES
 SUFFIX=$(shell python3-config --extension-suffix)
-# CXXFLAGS=-fPIC -O2 -stdlib=libc++ -std=c++14 -isystem ${PREFIX}/include
 SOEXT=.dylib
-# LDFLAGS="${LDFLAGS}"-Wl,-rpath,${PREFIX}/lib -L${PREFIX}/lib -mlinker-version=${TEST_LD_VER}
 endif
 
 test: clean pymod

--- a/recipe/pybind11_exception_rtti_test/README.md
+++ b/recipe/pybind11_exception_rtti_test/README.md
@@ -1,0 +1,45 @@
+# tests of exception passing in pybind11
+
+### install your env
+
+```bash
+conda create -n pybind11-test python=3.7 pybind11 compilers pytest git make
+```
+
+### run
+
+```bash
+make test
+```
+
+### license info
+
+```
+# This file is part of pex_exceptions.
+#
+# Developed for the LSST Data Management System.
+# This product includes software developed by the LSST Project
+# (https://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+```
+
+```
+Copyright 2008-2015 LSST Corporation
+Copyright 2016-2017 The Trustees of Princeton University
+Copyright 2016-2017 Association of Universities for Research in Astronomy
+Copyright 2017-2018 University of Washington
+```

--- a/recipe/pybind11_exception_rtti_test/README.md
+++ b/recipe/pybind11_exception_rtti_test/README.md
@@ -9,6 +9,8 @@ Thus we switched to linking libcxx against the system libcxxabi on osx.
 Going forward, we want to run this pybind11-based test each time we build
 libcxx for osx using the conda `downstreams` feature.
 
+The code here is a simplified version of the code in ` lsst/pex_exceptions`.
+
 ### install your env
 
 ```bash

--- a/recipe/pybind11_exception_rtti_test/README.md
+++ b/recipe/pybind11_exception_rtti_test/README.md
@@ -1,9 +1,18 @@
 # tests of exception passing in pybind11
 
+The backstory is that when we also built libcxxabi on osx, we saw issues where
+the RTTI was not making it between different compilations for exceptions when
+using pybind11. We (really @isuruf) figured out that by having only one copy of
+the libcxxabi lib (i.e., just the system one and not the one on conda), it fixed
+this issue. (On OSX the system one alwasy gets pulled in first by python).
+Thus we switched to linking libcxx against the system libcxxabi on osx.
+Going forward, we want to run this pybind11-based test each time we build
+libcxx for osx using the conda `downstreams` feature.
+
 ### install your env
 
 ```bash
-conda create -n pybind11-test python=3.7 pybind11 compilers pytest git make
+conda create -n pybind11-test python=3.7 pybind11 compilers git make
 ```
 
 ### run

--- a/recipe/pybind11_exception_rtti_test/exception_test/__init__.py
+++ b/recipe/pybind11_exception_rtti_test/exception_test/__init__.py
@@ -1,0 +1,1 @@
+from .wrappers import *  # noqa

--- a/recipe/pybind11_exception_rtti_test/exception_test/exceptions.cc
+++ b/recipe/pybind11_exception_rtti_test/exception_test/exceptions.cc
@@ -1,0 +1,72 @@
+#include <pybind11/pybind11.h>
+
+#include <cstdio>
+#include <sstream>
+
+#include "../src/Exception.h"
+
+namespace py = pybind11;
+
+/**
+ * Raise a Python exception that wraps the given C++ exception instance.
+ *
+ * Most of the work is delegated to the pure-Python function pex.exceptions.wrappers.translate(),
+ * which looks up the appropriate Python exception class from a dict that maps C++ exception
+ * types to their custom Python wrappers.  Everything else here is basically just importing that
+ * module, preparing the arguments, and calling that function, along with the very verbose error
+ * handling required by the Python C API.
+ *
+ * If any point we fail to translate the exception, we print a Python warning and raise the built-in
+ * Python RuntimeError exception with the same message as the C++ exception.
+ *
+ * @param pyex a wrapped instance of pex::exceptions::Exception
+ */
+void raiseLsstException(py::object &pyex) {
+    static auto module =
+            py::reinterpret_borrow<py::object>(PyImport_ImportModule("exception_test.wrappers"));
+    if (!module.ptr()) {
+        printf("Failed to import C++ Exception wrapper module.\n");
+    } else {
+        static auto translate =
+                py::reinterpret_borrow<py::object>(PyObject_GetAttrString(module.ptr(), "translate"));
+        if (!translate.ptr()) {
+            printf("Failed to find translation function for C++ Exceptions.\n");
+        } else {
+            // Calling the Python translate() returns an instance of the appropriate Python
+            // exception that wraps the C++ exception instance that we give it.
+            auto instance = py::reinterpret_steal<py::object>(
+                    PyObject_CallFunctionObjArgs(translate.ptr(), pyex.ptr(), NULL));
+            if (!instance.ptr()) {
+                // We actually expect a null return here, as translate() should raise an exception
+                printf("Failed to translate C++ Exception to Python.\n");
+            } else {
+                auto type = py::reinterpret_borrow<py::object>(PyObject_Type(instance.ptr()));
+                PyErr_SetObject(type.ptr(), instance.ptr());
+            }
+        }
+    }
+}
+
+PYBIND11_MODULE(exceptions, mod) {
+    py::class_<lsst_exceptions::LSSTException> clsLSSTException(mod, "LSSTException");
+    clsLSSTException.def(py::init<std::string const &>())
+            .def("what", &lsst_exceptions::LSSTException::what)
+            .def("clone", &lsst_exceptions::LSSTException::clone);
+
+    py::class_<lsst_exceptions::CustomError, lsst_exceptions::LSSTException> clsCustomError(mod, "CustomError");
+    clsCustomError.def(py::init<std::string const &>());
+
+    py::register_exception_translator([](std::exception_ptr p) {
+        try {
+            if (p) {
+              printf("\n==========\nstandard throw!\n==========\n");
+              std::rethrow_exception(p);
+            }
+        } catch (const lsst_exceptions::LSSTException &e) {
+            printf("\n==========\ncaught\n==========\n");
+            py::object current_exception;
+            current_exception = py::cast(e.clone(), py::return_value_policy::take_ownership);
+            raiseLsstException(current_exception);
+        }
+    });
+}

--- a/recipe/pybind11_exception_rtti_test/exception_test/wrappers.py
+++ b/recipe/pybind11_exception_rtti_test/exception_test/wrappers.py
@@ -1,0 +1,64 @@
+from . import exceptions
+
+__all__ = [
+    "register",
+    "LSSTException",
+    "translate",
+    "CustomError",
+]
+
+registry = {}
+
+
+def register(cls):
+    """A Python decorator that adds a Python exception wrapper to the
+    registry that maps C++ Exceptions to their Python wrapper classes.
+    """
+    registry[cls.WrappedClass] = cls
+    return cls
+
+
+@register
+class LSSTException(Exception):
+    """The base class for Python-wrapped LSST C++ exceptions.
+    """
+
+    # wrappers.py is an implementation detail, not a public namespace,
+    # so we pretend this is defined
+    # in the package for pretty-printing purposes
+    __module__ = "exceptions"
+
+    WrappedClass = exceptions.LSSTException
+
+    def __init__(self, arg, *args, **kwds):
+        if isinstance(arg, exceptions.LSSTException):
+            cpp = arg
+            message = cpp.what()
+        else:
+            message = arg
+            cpp = self.WrappedClass(message, *args, **kwds)
+        super(Exception, self).__init__(message)
+        self.cpp = cpp
+
+    def __getattr__(self, name):
+        return getattr(self.cpp, name)
+
+    def __repr__(self):
+        return "%s('%s')" % (type(self).__name__, self.cpp.what())
+
+    def __str__(self):
+        return self.cpp.what()
+
+
+@register
+class CustomError(LSSTException):
+    WrappedClass = exceptions.CustomError
+
+
+def translate(cpp):
+    """Translate a C++ Exception instance to Python and return it."""
+    PyType = registry.get(type(cpp), None)
+    if PyType is None:
+        print("Could not find appropriate Python type for C++ Exception")
+        PyType = Exception
+    return PyType(cpp)

--- a/recipe/pybind11_exception_rtti_test/setup.py
+++ b/recipe/pybind11_exception_rtti_test/setup.py
@@ -1,0 +1,7 @@
+from setuptools import setup, find_packages
+
+setup(
+    name='exception_test',
+    version='0.1.0',
+    packages=find_packages()
+)

--- a/recipe/pybind11_exception_rtti_test/src/Exception.cc
+++ b/recipe/pybind11_exception_rtti_test/src/Exception.cc
@@ -1,0 +1,18 @@
+#include <cstring>
+#include <ostream>
+#include <sstream>
+#include <string>
+
+#include "Exception.h"
+
+namespace lsst_exceptions {
+
+LSSTException::LSSTException(std::string const& message) : _message(message) {}
+
+LSSTException::~LSSTException(void) noexcept {}
+
+char const* LSSTException::what(void) const noexcept { return _message.c_str(); }
+
+LSSTException* LSSTException::clone(void) const { return new LSSTException(*this); }
+
+}  // namespace exceptions

--- a/recipe/pybind11_exception_rtti_test/src/Exception.h
+++ b/recipe/pybind11_exception_rtti_test/src/Exception.h
@@ -1,0 +1,30 @@
+#ifndef EXCEPTION_H
+#define EXCEPTION_H
+
+#include <exception>
+#include <ostream>
+#include <string>
+
+#define LSST_EXPORT __attribute__ ((visibility("default")))
+
+namespace lsst_exceptions {
+
+class LSST_EXPORT LSSTException : public std::exception {
+  public:
+      LSSTException(std::string const& message);
+      virtual ~LSSTException(void) noexcept;
+      virtual char const* what(void) const noexcept;
+      virtual LSSTException* clone(void) const;
+  private:
+      std::string _message;
+};
+
+class LSST_EXPORT CustomError : public LSSTException {
+  public:
+      CustomError(std::string const& message) : LSSTException(message){};
+      virtual lsst_exceptions::LSSTException* clone(void) const { return new lsst_exceptions::CustomError(*this); };
+};
+
+}
+
+#endif

--- a/recipe/pybind11_exception_rtti_test/tests/testLib.cc
+++ b/recipe/pybind11_exception_rtti_test/tests/testLib.cc
@@ -1,0 +1,8 @@
+#include <string>
+#include <pybind11/pybind11.h>
+#include "../src/Exception.h"
+
+PYBIND11_MODULE(testLib, mod) {
+  mod.def("failLSSTException", [](const std::string &message) { throw lsst_exceptions::LSSTException(message); });
+  mod.def("failCustomError", [](const std::string &message) { throw lsst_exceptions::CustomError(message); });
+}

--- a/recipe/pybind11_exception_rtti_test/tests/test_exception_catching_python.py
+++ b/recipe/pybind11_exception_rtti_test/tests/test_exception_catching_python.py
@@ -1,0 +1,34 @@
+from __future__ import print_function
+import exception_test  # noqa
+import testLib
+
+
+try:
+    testLib.failLSSTException("message1")
+except Exception as e:
+    print("\nexception:", repr(e), "\n")
+    assert repr(e) == "LSSTException('message1')"
+
+
+try:
+    testLib.failCustomError("message2")
+except Exception as e:
+    print("\nexception:", repr(e), "\n")
+    assert repr(e) == "CustomError('message2')"
+
+
+try:
+    testLib.failLSSTException("message3")
+except exception_test.LSSTException as e:
+    print("\nexception:", repr(e), "\n")
+    assert repr(e) == "LSSTException('message3')"
+
+
+try:
+    testLib.failCustomError("message4")
+except exception_test.LSSTException as e:
+    print("\nexception:", repr(e), "\n")
+    assert repr(e) == "CustomError('message4')"
+
+
+print("\nPASSED")

--- a/recipe/run_exception_rtti_test.sh
+++ b/recipe/run_exception_rtti_test.sh
@@ -1,0 +1,8 @@
+set -e
+
+info=$( ld -v 2>&1 > /dev/null )
+export TEST_LD_VER=`echo "${info}" | perl -wne '/.ld64-(.*?)[^0-9]/ and print "$1\n"'`
+
+pushd pybind11_exception_rtti_test
+make test
+popd

--- a/recipe/run_exception_rtti_test.sh
+++ b/recipe/run_exception_rtti_test.sh
@@ -1,8 +1,5 @@
 set -e
 
-info=$( ld -v 2>&1 > /dev/null )
-export TEST_LD_VER=`echo "${info}" | perl -wne '/.ld64-(.*?)[^0-9]/ and print "$1\n"'`
-
 pushd pybind11_exception_rtti_test
 make test
 popd


### PR DESCRIPTION
We want to add this test of exception passing in pybind11 on osx here so that we can use it to test builds of libcxx. The backstory is that when we also built libcxxabi on osx, we saw issues where the RTTI was not making it between different compilations. We figured out that by having only one copy of the libcxxabi lib (i.e., just the system one and not the one on conda), it fixed this issue. Going forward, we want to run this pybind11-based test each time we build libcxx for osx.

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
