### PR TITLE
Bump pybind11-abi to 10 to reflect the fact that `PYBIND11_INTERNALS_ID` is not used anymore to track compatibility

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -15,7 +15,7 @@ source:
   sha256: {{ sha256 }}
 
 build:
-  number: 0
+  number: 1
 
 requirements:
   build:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,8 +1,9 @@
 {% set version = "2.13.6" %}
 {% set sha256 = "e08cb87f4773da97fa7b5f035de8763abc656d87d5773e62f6da0587d1f0ec20" %}
 
-# this is set to PYBIND11_INTERNALS_VERSION
-{% set abi_version = "4" %}
+# Since pybind11 2.13.6, 2.12.1, 2.11.2, PYBIND11_INTERNALS_VERSION is not used anymore
+# to check for compatibility between different,
+{% set abi_version = "10" %}
 
 package:
   name: pybind11-split
@@ -29,12 +30,6 @@ outputs:
       skip: true  # [not linux64]
       run_exports:
         - pybind11-abi =={{ abi_version }}
-    test:
-      source_files:
-        - include/pybind11/detail/internals.h
-      commands:
-        # make sure the internals version matches the package version
-        - if [ $(grep "#define PYBIND11_INTERNALS_VERSION" include/pybind11/detail/internals.h | cut -d' ' -f3) != "{{ abi_version }}" ]; then exit 1; fi
 
   - name: pybind11-global
     script: build-pybind11-global.sh  # [unix]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -30,6 +30,10 @@ outputs:
       skip: true  # [not linux64]
       run_exports:
         - pybind11-abi =={{ abi_version }}
+    test:
+      commands:
+        - echo "pybind11-abi is a metapackage, no test is necessary."
+
 
   - name: pybind11-global
     script: build-pybind11-global.sh  # [unix]


### PR DESCRIPTION
See discussion in https://github.com/conda-forge/pybind11-feedstock/issues/96#issuecomment-2366829296 .

The idea is that since https://github.com/pybind/pybind11/pull/5296 `PYBIND11_INTERNALS_ID` is not used anymore to assess compatibility between library compiled with different pybind11 versions, it does not make sense anymore for `pybind11-abi` to track `PYBIND11_INTERNALS_ID`.

For this reason, this PR also remove the check that  `pybind11-abi` is equal to `PYBIND11_INTERNALS_ID`.

Fix https://github.com/conda-forge/pybind11-feedstock/issues/96 .

Note that this will not solve or handle the fact that pybind11 bindings compiled with different gcc or clang major versions (https://github.com/conda-forge/pybind11-feedstock/issues/77) or msvc minor versions (https://github.com/conda-forge/pybind11-feedstock/issues/95) are incompatible.

Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
